### PR TITLE
Adds various improvements to exported worksheet aesthetics

### DIFF
--- a/lib/worksheet-service.js
+++ b/lib/worksheet-service.js
@@ -45,6 +45,9 @@ lib.exportToWorksheet = metadata => {
         })
       })
 
+      // :: add an empty row after each directory
+      worksheet.addRow([])
+
       dirTask.done()
     })
 

--- a/lib/worksheet-service.js
+++ b/lib/worksheet-service.js
@@ -2,11 +2,28 @@ const chalk = require('chalk')
 const xlsx = require('exceljs')
 const groupBy = require('lodash/groupBy')
 const each = require('lodash/each')
+const merge = require('lodash/merge')
+
 const logger = require('./logging-service')
+const styling = require('./worksheet-styling')
 
 const lib = {}
 
+// :: styling information
+workbookFont = merge({}, styling.font)
+workbookAlignment = merge({}, styling.alignment)
+
+directoryFont = merge({}, workbookFont, {
+  color: { argb: 'FF000000' },
+  bold: true
+})
+directoryAlignment = merge({}, workbookAlignment)
+
+songFont = merge({}, workbookFont)
+songAlignment = merge({}, workbookAlignment)
+
 function initializeWorksheet() {
+
   const workbook = new xlsx.Workbook()
   const worksheet = workbook.addWorksheet('DTX Files')
 
@@ -15,6 +32,9 @@ function initializeWorksheet() {
     { header: 'Artist', key: 'artist', width: 32 },
     { header: 'Comments', key: 'comments', width: 50 }
   ]
+
+  worksheet.lastRow.font = workbookFont
+  worksheet.lastRow.alignment = workbookAlignment
 
   return { workbook, worksheet }
 }
@@ -33,21 +53,34 @@ lib.exportToWorksheet = metadata => {
       let reduce = 0
 
       task.details(dir)
-      worksheet.addRow({ title: dir })
+
+      // :: set directory row styling
+      const row = worksheet.addRow({ title: dir })
 
       each(files, file => {
         dirTask.details(`${++reduce} songs flushed.`)
 
-        worksheet.addRow({
+        const row = worksheet.addRow({
           title: file.title,
           artist: file.author,
           comments: file.comments || ''
         })
+
+        // :: styling information ---
+        row.font = songFont
+        row.alignment = songAlignment
+
+        row.getCell(1).alignment = merge({}, songAlignment, {
+          indent: 2
+        })
       })
+
+      // :: styling information ---
+      row.font = directoryFont
+      row.alignment = directoryAlignment
 
       // :: add an empty row after each directory
       worksheet.addRow([])
-
       dirTask.done()
     })
 

--- a/lib/worksheet-service.js
+++ b/lib/worksheet-service.js
@@ -1,5 +1,8 @@
 const chalk = require('chalk')
 const xlsx = require('exceljs')
+
+const _ = require('lodash')
+
 const groupBy = require('lodash/groupBy')
 const each = require('lodash/each')
 const merge = require('lodash/merge')
@@ -12,15 +15,23 @@ const lib = {}
 // :: styling information
 workbookFont = merge({}, styling.font)
 workbookAlignment = merge({}, styling.alignment)
+workbookFill = merge({}, styling.fill)
 
 directoryFont = merge({}, workbookFont, {
   color: { argb: 'FF000000' },
   bold: true
 })
 directoryAlignment = merge({}, workbookAlignment)
+directoryFill = merge({}, styling.fill, {
+  type: 'pattern',
+  pattern: 'solid',
+  bgColor: { argb: 'FFEEEEEE' },
+  fgColor: { argb: 'FFEEEEEE' }
+})
 
 songFont = merge({}, workbookFont)
 songAlignment = merge({}, workbookAlignment)
+songFill = merge({}, workbookFill)
 
 function initializeWorksheet() {
 
@@ -35,16 +46,23 @@ function initializeWorksheet() {
 
   worksheet.lastRow.font = workbookFont
   worksheet.lastRow.alignment = workbookAlignment
+  worksheet.lastRow.fill = workbookFill
 
   return { workbook, worksheet }
+}
+
+function validateSong(file) {
+  return !!((file.title || '').trim())
 }
 
 lib.exportToWorksheet = metadata => {
   const task = logger.add('Preparing workbook')
   task.status('initializing').details('Creating workbook')
+
   const { workbook, worksheet } = initializeWorksheet()
 
   return new Promise((resolve, reject) => {
+
     task.status('flushing')
 
     const groups = groupBy(metadata, m => m.dir)
@@ -57,31 +75,44 @@ lib.exportToWorksheet = metadata => {
       // :: set directory row styling
       const row = worksheet.addRow({ title: dir })
 
-      each(files, file => {
-        dirTask.details(`${++reduce} songs flushed.`)
+      _.chain(files)
+        .filter(file => validateSong(file))
+        .each(file => {
+          const row = worksheet.addRow({
+            title: file.title,
+            artist: file.author,
+            comments: file.comments || ''
+          })
 
-        const row = worksheet.addRow({
-          title: file.title,
-          artist: file.author,
-          comments: file.comments || ''
+          // :: styling information ---
+          row.font = songFont
+          row.alignment = songAlignment
+          row.fill = songFill
+
+          row.getCell(1).alignment = merge({}, songAlignment, {
+            indent: 2
+          })
+
+          dirTask.details(`${++reduce} songs flushed.`)
         })
+        .commit()
 
+      // :: just in case nothing was added
+      if (reduce === 0) {
+        row.hidden = true
+        dirTask.details('No valid files found.').fail(row.number + '')
+      } else {
         // :: styling information ---
-        row.font = songFont
-        row.alignment = songAlignment
+        row.font = directoryFont
+        row.alignment = directoryAlignment
+        row.fill = directoryFill
 
-        row.getCell(1).alignment = merge({}, songAlignment, {
-          indent: 2
-        })
-      })
+        row.height = directoryFont.size * 1.8
 
-      // :: styling information ---
-      row.font = directoryFont
-      row.alignment = directoryAlignment
-
-      // :: add an empty row after each directory
-      worksheet.addRow([])
-      dirTask.done()
+        // :: add an empty row after each directory
+        worksheet.addRow(['']).fill = workbookFill
+        dirTask.done()
+      }
     })
 
     const filename = `dtxsongs_${Date.now()}.xlsx`

--- a/lib/worksheet-service.js
+++ b/lib/worksheet-service.js
@@ -66,54 +66,59 @@ lib.exportToWorksheet = metadata => {
     task.status('flushing')
 
     const groups = groupBy(metadata, m => m.dir)
-    each(groups, (files, dir) => {
-      const dirTask = logger.add(`Flush: ${dir}`)
-      let reduce = 0
 
-      task.details(dir)
+    _.chain(metadata)
+      .groupBy(m => m.dir)
+      .each((files, dir) => {
+        const dirTask = logger.add(`Flush: ${dir}`)
+        let reduce = 0
 
-      // :: set directory row styling
-      const row = worksheet.addRow({ title: dir })
+        task.details(dir)
 
-      _.chain(files)
-        .filter(file => validateSong(file))
-        .each(file => {
-          const row = worksheet.addRow({
-            title: file.title,
-            artist: file.author,
-            comments: file.comments || ''
+        // :: set directory row styling
+        const row = worksheet.addRow({ title: dir })
+
+        _.chain(files)
+          .filter(file => validateSong(file))
+          .sortBy(file => file.title)
+          .each(file => {
+            const row = worksheet.addRow({
+              title: file.title,
+              artist: file.author,
+              comments: file.comments || ''
+            })
+
+            // :: styling information ---
+            row.font = songFont
+            row.alignment = songAlignment
+            row.fill = songFill
+
+            row.getCell(1).alignment = merge({}, songAlignment, {
+              indent: 2
+            })
+
+            dirTask.details(`${++reduce} songs flushed.`)
           })
+          .commit()
 
+        // :: just in case nothing was added
+        if (reduce === 0) {
+          row.hidden = true
+          dirTask.details('No valid files found.').fail('Empty')
+        } else {
           // :: styling information ---
-          row.font = songFont
-          row.alignment = songAlignment
-          row.fill = songFill
+          row.font = directoryFont
+          row.alignment = directoryAlignment
+          row.fill = directoryFill
 
-          row.getCell(1).alignment = merge({}, songAlignment, {
-            indent: 2
-          })
+          row.height = directoryFont.size * 1.8
 
-          dirTask.details(`${++reduce} songs flushed.`)
-        })
-        .commit()
-
-      // :: just in case nothing was added
-      if (reduce === 0) {
-        row.hidden = true
-        dirTask.details('No valid files found.').fail(row.number + '')
-      } else {
-        // :: styling information ---
-        row.font = directoryFont
-        row.alignment = directoryAlignment
-        row.fill = directoryFill
-
-        row.height = directoryFont.size * 1.8
-
-        // :: add an empty row after each directory
-        worksheet.addRow(['']).fill = workbookFill
-        dirTask.done()
-      }
-    })
+          // :: add an empty row after each directory
+          worksheet.addRow(['']).fill = workbookFill
+          dirTask.done()
+        }
+      })
+      .commit()
 
     const filename = `dtxsongs_${Date.now()}.xlsx`
     task.status('finalizing').details(filename)

--- a/lib/worksheet-styling.js
+++ b/lib/worksheet-styling.js
@@ -1,0 +1,16 @@
+const merge = require('lodash/merge')
+
+const styling = {
+  font: {
+    name: 'Calibri',
+    color: { argb: 'FF444444' },
+    size: 10,
+    italic: false
+  },
+  alignment: {
+    horizontal: 'left',
+    vertical: 'middle'
+  }
+}
+
+module.exports = styling

--- a/lib/worksheet-styling.js
+++ b/lib/worksheet-styling.js
@@ -10,6 +10,12 @@ const styling = {
   alignment: {
     horizontal: 'left',
     vertical: 'middle'
+  },
+  fill: {
+    type: 'pattern',
+    pattern: 'solid',
+    bgColor: { argb: 'FFFFFFFF' },
+    fgColor: { argb: 'FFFFFFFF' }
   }
 }
 


### PR DESCRIPTION
> Addresses #1 

This PR includes the following improvements for exported worksheets:

- Adds an empty row after each directory
- Adds styling to the worksheet
  - Directory names are **bold**, with a light gray background
  - Song names are of default styling, with a small indent to make it easier to scanm

- Sorts the songs listed in a directory based on their artist

Also makes the script complain when a directory **seems** to have songs in it, but the script could not find any valid song files in it (for example, when it finds a malformed `set.def` file).

![image](https://user-images.githubusercontent.com/705310/29240142-47eb2c86-7fa2-11e7-84f0-286273f4e6f0.png)
